### PR TITLE
docs: actualizar README con integración Mercado Pago

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Cada ejecucion del pipeline queda trackeada en LangSmith con:
 - Diario de lecturas en `localStorage`.
 - Carta diaria y horoscopo semanal.
 - Tarjeta compartible para redes sociales.
+- Pasarela de pago integrada con Mercado Pago para compra de créditos (packs y lectura individual).
 
 ---
 
@@ -237,6 +238,8 @@ En Vercel (`Settings -> Environment Variables`):
 - `UPSTASH_REDIS_REST_URL`
 - `UPSTASH_REDIS_REST_TOKEN`
 - `DEMO_MODE`
+- `MP_ACCESS_TOKEN`
+- `APP_URL`
 
 Notas:
 
@@ -245,6 +248,24 @@ Notas:
 - Upstash Redis guarda hasta 50 lecturas por usuario usando `lpush` + `ltrim`.
 
 ---
+
+
+### Pasarela de pago (Mercado Pago)
+
+Se incorporó una pasarela de pago con **Mercado Pago Checkout** para monetizar lecturas adicionales mediante créditos.
+
+Flujo:
+
+1. El frontend solicita una preferencia con `POST /api/create-preference` enviando `userId` y `pack`.
+2. El backend crea la preferencia en Mercado Pago y devuelve `init_point` para redirigir al checkout.
+3. Mercado Pago notifica el pago en `/api/mp-webhook`.
+4. El webhook valida el pago `approved`, evita duplicados por `paymentId` y acredita créditos en Redis (`credits:paid:{userId}`).
+5. La app consume créditos con `/api/use-credit` y consulta saldo con `/api/check-credits`.
+
+Packs configurados actualmente:
+
+- `single`: 1 lectura
+- `pack5`: 5 lecturas
 
 ## Desarrollo local
 
@@ -286,6 +307,8 @@ Configurar en Vercel:
 - `UPSTASH_REDIS_REST_URL`: URL de tu base de datos en upstash.com
 - `UPSTASH_REDIS_REST_TOKEN`: token de tu base de datos en upstash.com
 - `DEMO_MODE`: `false` en produccion
+- `MP_ACCESS_TOKEN`: access token privado de Mercado Pago
+- `APP_URL`: URL pública de la app (usada para `success/failure/pending`)
 
 ---
 


### PR DESCRIPTION
### Motivation

- Documentar la nueva pasarela de pago integrada con Mercado Pago para permitir la compra de créditos (packs y lectura individual). 
- Registrar las variables de entorno necesarias y describir el flujo de pago para aclarar la implementación del backend y el consumo de créditos.

### Description

- Se añadió una línea en las funcionalidades del producto indicando la integración de Mercado Pago para la compra de créditos. 
- Se incluyeron las variables de entorno `MP_ACCESS_TOKEN` y `APP_URL` en la sección de configuración (local y Vercel). 
- Se agregó la sección "Pasarela de pago (Mercado Pago)" que detalla el flujo: creación de preferencia (`/api/create-preference`), redirección al `init_point`, webhook (`/api/mp-webhook`) que valida y acredita créditos en Redis, y la interacción con `/api/use-credit` y `/api/check-credits`. 
- Se documentaron los packs disponibles actualmente (`single` y `pack5`).

### Testing

- Se ejecutaron comprobaciones automatizadas de diferencias sobre `README.md` y las operaciones de publicación del PR, las cuales finalizaron correctamente. 
- No hay pruebas unitarias automatizadas asociadas a cambios de documentación, por lo que no se ejecutaron tests de lógica de negocio en este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a036c0b13f483218699f338116231b1)